### PR TITLE
Fix icon sizing issues in Safari

### DIFF
--- a/src/features/Toast/Toast.svelte
+++ b/src/features/Toast/Toast.svelte
@@ -24,10 +24,10 @@
 
 <div
   class="min-h-12 pointer-events-auto inline-flex items-center rounded bg-red-900 py-2 ps-2.5 text-white">
-  <Alert class="shrink-0" />
+  <Alert class="h-4 w-4 shrink-0" />
   <span
     class="flex h-full items-center border-r border-white/30 px-2.5 align-middle text-body"
     >{$_(toastItem.messageId)}</span>
   <button on:click={toastItem.close} class="shrink-0 p-2"
-    ><Close height="1rem" /></button>
+    ><Close class="h-4 w-4" /></button>
 </div>

--- a/src/routes/verify/components/Compare/ComparePanel/ComparePanel.svelte
+++ b/src/routes/verify/components/Compare/ComparePanel/ComparePanel.svelte
@@ -47,8 +47,8 @@
       class="me-2"
       on:click={() => verifyStore.setHierarchyView()}
       aria-roledescription={$_('sidebar.verify.compare.back')}>
-      <div class="flex px-5 py-5 pb-2">
-        <BackArrow class="me-2" />
+      <div class="flex items-center px-5 py-5 pb-2">
+        <BackArrow class="relative -top-px me-2 h-4 w-4 shrink" />
         <Header>{$_('sidebar.verify.compare')}</Header>
       </div>
     </button>

--- a/src/routes/verify/components/ErrorBanner/ErrorBanner.svelte
+++ b/src/routes/verify/components/ErrorBanner/ErrorBanner.svelte
@@ -28,9 +28,9 @@
   <IconContentRow>
     <svelte:fragment slot="icon">
       {#if type === 'warning'}
-        <Alert />
+        <Alert class="h-4 w-4" />
       {:else}
-        <Info />
+        <Info class="h-4 w-4" />
       {/if}
     </svelte:fragment>
     <div class="grow" slot="content">


### PR DESCRIPTION
## Overview

This PR contains the following change(s):
- Fixes icon sizing issues in Safari - turns out Safari will make them expand unless we explicitly put a width/height on them.

## Checklist

- [ ] End-to-end or unit tests (where applicable) have been added that cover this change/bug fix
- [ ] Any UI changes display properly on mobile breakpoints
- [ ] Any user-visible strings have accompanying translation tags
- [ ] Accessibility support has been added
- [ ] Analytics are being sent (where applicable)

## Issue link (optional)

_Please insert link(s) to any related issue(s) here_
