### PR TITLE
Run Percy/tests on main branch

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -79,7 +79,7 @@ jobs:
     # - we open up a pull request that's not a draft
     # - we mark a pull request as ready for review
     # - we label a pull request with the snapshot requested tag
-    if: ${{(github.ref == 'refs/heads/main' && github.event.action == 'push') || (!github.event.pull_request.draft && github.event.action == 'opened') || github.event.action == 'ready_for_review' || (github.event.action == 'labeled' && github.event.label.name == vars.SNAPSHOT_TRIGGER_LABEL) }}
+    if: ${{ (github.ref == 'refs/heads/main' && github.event.action == 'push') || (!github.event.pull_request.draft && github.event.action == 'opened') || github.event.action == 'ready_for_review' || (github.event.action == 'labeled' && github.event.label.name == vars.SNAPSHOT_TRIGGER_LABEL) }}
     timeout-minutes: 60
     env:
       PERCY_POSTINSTALL_BROWSER: true


### PR DESCRIPTION
## Overview

This will run Percy/tests when a push is made to `main` so that Percy can set a new baseline for snapshot testing.

## Checklist

- [ ] End-to-end or unit tests (where applicable) have been added that cover this change/bug fix
- [ ] Any UI changes display properly on mobile breakpoints
- [ ] Any user-visible strings have accompanying translation tags
- [ ] Accessibility support has been added
- [ ] Analytics are being sent (where applicable)

## Issue link (optional)

_Please insert link(s) to any related issue(s) here_
