### PR TITLE
Fix for version showing as undefined for claim_generator_info 

### DIFF
--- a/e2e/c2pa-test-image-service.config.ts
+++ b/e2e/c2pa-test-image-service.config.ts
@@ -473,5 +473,18 @@ export default {
         format: 'image/jpeg',
       },
     },
+    'claim-generator-info-no-version': {
+      image: { r: 0, g: 0, b: 255, width: 600, height: 600 },
+      manifest: {
+        title: 'Claim Generator Image.jpg',
+        claim_generator: 'Claim Generator V1',
+        claim_generator_info: [
+          {
+            name: 'Claim Generator',
+          },
+        ],
+        format: 'image/jpeg',
+      },
+    },
   },
 } satisfies C2paTestImageServiceConfig;

--- a/e2e/snapshot/assertions.spec.ts
+++ b/e2e/snapshot/assertions.spec.ts
@@ -177,4 +177,19 @@ test.describe('Verify - assertion display', () => {
       widths: [1024],
     });
   });
+
+  test('image with claim_generator v2 without a version should display correctly', async ({
+    page,
+  }) => {
+    const verify = new VerifyPage(page);
+    await page.setViewportSize({ width: 1024, height: 1024 });
+    const source = VerifyPage.getFixtureUrl('claim-generator-info-no-version');
+    await verify.goto(source);
+    await verify.takeSnapshot(
+      'result for image with claim generator v2 no version',
+      {
+        widths: [1024],
+      },
+    );
+  });
 });

--- a/src/lib/asset.ts
+++ b/src/lib/asset.ts
@@ -288,7 +288,7 @@ export async function resultToAssetMap({
         ? new Date(manifest.signatureInfo.time)
         : null,
       claimGenerator: claimGeneratorInfo?.name
-        ? `${claimGeneratorInfo.name} ${claimGeneratorInfo?.version}`
+        ? `${claimGeneratorInfo.name} ${claimGeneratorInfo?.version ?? ''}`
         : selectFormattedGenerator(manifest),
       signatureInfo: manifest.signatureInfo,
       producer: selectProducer(manifest)?.name ?? null,


### PR DESCRIPTION
## Overview

This PR contains the following change(s):

- Added check for version not being undefined

## Checklist

- [ ] End-to-end or unit tests (where applicable) have been added that cover this change/bug fix
- [ ] Any UI changes display properly on mobile breakpoints
- [ ] Any user-visible strings have accompanying translation tags
- [ ] Accessibility support has been added
- [ ] Analytics are being sent (where applicable)

## Issue link (optional)

_Please insert link(s) to any related issue(s) here_
