### PR TITLE
fix: asset reference assertion schema

### DIFF
--- a/src/lib/selectors/website.ts
+++ b/src/lib/selectors/website.ts
@@ -12,14 +12,14 @@ declare module 'c2pa' {
   }
   interface ExtendedAssertions {
     'c2pa.asset-ref': {
-      resources: Resource[];
+      references: Resource[];
     };
   }
 }
 
 export function selectWebsite(manifest: Manifest): string | null {
   const site =
-    manifest.assertions.get('c2pa.asset-ref')[0]?.data.resources[0]?.reference
+    manifest.assertions.get('c2pa.asset-ref')[0]?.data.references[0]?.reference
       .uri ??
     manifest.assertions.get('stds.schema-org.CreativeWork')[0]?.data.url;
 


### PR DESCRIPTION
## Overview

This PR contains the following change(s):

The schema for the Asset Reference assertion says that the key is `references`, not `resources`. I believe this was a typo.

## Checklist

- [ ] End-to-end or unit tests (where applicable) have been added that cover this change/bug fix
- [ ] Any UI changes display properly on mobile breakpoints
- [ ] Any user-visible strings have accompanying translation tags
- [ ] Accessibility support has been added
- [ ] Analytics are being sent (where applicable)
