### PR TITLE
fix: remove all contentcredentials.org references in the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# contentcredentials.org
+# verify.contentauthenticity.org
 
-This project generates the code for the contentcredentials.org site.
+This project generates the code for the verify.contentauthenticity.org site.
 
 ## Getting Started
 
@@ -44,7 +44,7 @@ localStorage.debug = 'toolkit,store';
 localStorage.debug = false;
 ```
 
-This will enable debug logging in the browser console for both the contentcredentials.org site as well as our [JavaScript SDK](https://github.com/contentauth/c2pa-js).
+This will enable debug logging in the browser console for both the verify.contentauthenticity.org site as well as our [JavaScript SDK](https://github.com/contentauth/c2pa-js).
 
 ## Development
 

--- a/src/app.html
+++ b/src/app.html
@@ -13,8 +13,8 @@
       content="Introducing the new standard for content authentication. Content Credentials provide deeper transparency into how content was created or edited." />
     <meta
       property="og:image"
-      content="https://contentcredentials.org/opengraph.png" />
-    <meta property="og:url" content="https://www.contentcredentials.org/" />
+      content="https://verify.contentauthenticity.org/opengraph.png" />
+    <meta property="og:url" content="https://www.verify.contentauthenticity.org/" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@ContentCreds" />
     <meta name="twitter:creator" content="@ContentCreds" />
@@ -24,7 +24,7 @@
       content="Introducing the new standard for content authentication. Content Credentials provide deeper transparency into how content was created or edited." />
     <meta
       name="twitter:image"
-      content="https://contentcredentials.org/opengraph.png" />
+      content="https://verify.contentauthenticity.org/opengraph.png" />
     <meta name="twitter:image:alt" content="Content Credentials" />
 
     <meta name="linkedin:title" content="Content Credentials" />
@@ -33,7 +33,7 @@
       content="Introducing the new standard for content authentication. Content Credentials provide deeper transparency into how content was created or edited." />
     <meta
       name="linkedin:image"
-      content="https://contentcredentials.org/opengraph.png" />
+      content="https://verify.contentauthenticity.org/opengraph.png" />
     <meta name="linkedin:image:alt" content="Content Credentials" />
 
     <!-- Site config -->

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,7 +13,7 @@ declare global {
   }
 }
 
-export const APP_NAME = 'contentcredentials.org';
+export const APP_NAME = 'verify.contentauthenticity.org';
 export const SITE_VERSION = version;
 export const DATA_PRIVACY_URL =
   'https://contentauthenticity.org/faq#:~:text=Why%20is%20there%20a%20gap%20in%20an%20image%E2%80%99s%20CAI%20data%3F';


### PR DESCRIPTION
## Overview

This PR contains the following change(s):

We are moving the site to verify.contentauthenticity.org , there should not be any references to contentcredentials.org in the README and the open Graph meta tags should point to an asset hosted on verify.contentauthenticity.org

## Checklist

- [ ] End-to-end or unit tests (where applicable) have been added that cover this change/bug fix
- [ ] Any UI changes display properly on mobile breakpoints
- [ ] Any user-visible strings have accompanying translation tags
- [ ] Accessibility support has been added
- [ ] Analytics are being sent (where applicable)

## Issue link (optional)

_Please insert link(s) to any related issue(s) here_
