### PR TITLE
Fix: Render the softwareAgent name instead of [object Object]

### DIFF
--- a/src/routes/verify/components/DetailedInfo/ProcessSection/AISubSection.svelte
+++ b/src/routes/verify/components/DetailedInfo/ProcessSection/AISubSection.svelte
@@ -17,7 +17,7 @@
     {#each softwareAgents as softwareAgent}
       <AboutSectionIconContentRow>
         <svelte:fragment slot="content">
-          {softwareAgent}</svelte:fragment>
+          {softwareAgent.name}</svelte:fragment>
       </AboutSectionIconContentRow>
     {/each}
   </svelte:fragment>


### PR DESCRIPTION
## Overview

This PR contains the following change(s):

Simple fix for showing the name of the software agent.

Here is what rendered before:
<img width="298" height="389" alt="image" src="https://github.com/user-attachments/assets/d11b22d0-2ea0-4869-a378-364e1c958ac7" />

Here is after:
<img width="291" height="344" alt="image" src="https://github.com/user-attachments/assets/0333cd4e-e6d7-4505-a974-43eb99ef3764" />

If you are curious, the image was just a standard image generated from chatgpt:
<img width="1024" height="1536" alt="ChatGPT Image Nov 20, 2025 at 09_28_31 AM" src="https://github.com/user-attachments/assets/063602ed-a1d8-4074-92c3-aeb2fe4b010a" />

I am not sure about the testing infrastructure in place, let me know if it is necessary.

## Checklist

- [ ] End-to-end or unit tests (where applicable) have been added that cover this change/bug fix
- [ ] Any UI changes display properly on mobile breakpoints
- [ ] Any user-visible strings have accompanying translation tags
- [ ] Accessibility support has been added
- [ ] Analytics are being sent (where applicable)
